### PR TITLE
Update README (remove itertools note)

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,6 @@ Cargo subcommand to profile binaries.
 
 * 0.1.3 - cargo better integrated. No longer have to specify binary if in rust project w/ cargo.toml. better error messages and exits (e.g. upon compilation errors).
 
-## Known Issues
-
-* Seems like itertools/ndarray (and thus cargo-profiler) isn't compiling on nightly versions > 05-11-2016. Use a nightly version before this date, or stable.
-
 ## To install
 
 NOTE: This subcommand can only be used on Linux machines.


### PR DESCRIPTION
The regression that broke itertools has been fixed in nightly (affected two days) and it was also worked around in itertools after 1 day, so it doesn't apply anymore.
