### PR TITLE
add support for command argument passthrough

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,13 @@ You can also specify a binary directly:
 $ cargo profiler callgrind --bin $PATH_TO_BINARY
 ```
 
+To specify command line arguments to the executable being profiled, append them
+after a `--`:
+
+```
+$ cargo profiler callgrind --bin $PATH_TO_BINARY -- -a 3 --like this
+```
+
 You can limit the number of functions you'd like to look at:
 
 ```

--- a/src/parse/cachegrind.rs
+++ b/src/parse/cachegrind.rs
@@ -7,6 +7,8 @@ use profiler::Profiler;
 use std::cmp::Ordering::Less;
 use err::ProfError;
 use regex::Regex;
+use std::ffi::OsStr;
+
 /// initialize matrix object
 pub type Mat<A> = OwnedArray<A, (Ix, Ix)>;
 
@@ -37,7 +39,7 @@ pub fn sort_matrix(mat: &Mat<f64>, sort_col: ArrayView<f64, Ix>) -> (Mat<f64>, V
 /// Parser trait. To parse the output of Profilers, we first have to get their output from
 /// the command line, and then parse the output into respective structs.
 pub trait CacheGrindParser {
-    fn cachegrind_cli(&self, binary: &str) -> Result<String, ProfError>;
+    fn cachegrind_cli(&self, binary: &str, binargs: &[&OsStr]) -> Result<String, ProfError>;
     fn cachegrind_parse<'b>(&'b self,
                             output: &'b str,
                             num: usize,
@@ -51,13 +53,14 @@ pub trait CacheGrindParser {
 
 impl CacheGrindParser for Profiler {
     /// Get profiler output from stdout.
-    fn cachegrind_cli(&self, binary: &str) -> Result<String, ProfError> {
+    fn cachegrind_cli(&self, binary: &str, binargs: &[&OsStr]) -> Result<String, ProfError> {
 
         // get cachegrind cli output from stdout
         let _ = Command::new("valgrind")
                     .arg("--tool=cachegrind")
                     .arg("--cachegrind-out-file=cachegrind.out")
                     .arg(binary)
+                    .args(binargs)
                     .output()
                     .or(Err(ProfError::CliError));
 

--- a/src/parse/callgrind.rs
+++ b/src/parse/callgrind.rs
@@ -4,24 +4,26 @@ use std::process::Command;
 use profiler::Profiler;
 use err::ProfError;
 use regex::Regex;
+use std::ffi::OsStr;
 
 // Parser trait. To parse the output of Profilers, we first have to get their output from
 // the command line, and then parse the output into respective structs.
 pub trait CallGrindParser {
-    fn callgrind_cli(&self, binary: &str) -> Result<String, ProfError>;
+    fn callgrind_cli(&self, binary: &str, binargs: &[&OsStr]) -> Result<String, ProfError>;
     fn callgrind_parse<'b>(&'b self, output: &'b str, num: usize) -> Result<Profiler, ProfError>;
 }
 
 
 impl CallGrindParser for Profiler {
     // Get profiler output from stdout.
-    fn callgrind_cli(&self, binary: &str) -> Result<String, ProfError> {
+    fn callgrind_cli(&self, binary: &str, binargs: &[&OsStr]) -> Result<String, ProfError> {
 
         // get callgrind cli output from stdout
         Command::new("valgrind")
             .arg("--tool=callgrind")
             .arg("--callgrind-out-file=callgrind.out")
             .arg(binary)
+            .args(binargs)
             .output()
             .unwrap_or_else(|e| panic!("failed to execute process: {}", e));
 


### PR DESCRIPTION
See the changes to README.md for an example.

The use of `&[&OsStr]` as the type signature follows the type signatures of
`std::process::Command::args` and `clap::ArgMatches::value_of_os`.

This addresses github issue #7 ("How do I provide arguments to the binary?").
