### PR TITLE
Fix author and version metadata in subcommands

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -36,6 +36,9 @@ fn main() {
 // #[cfg(all(unix, any(target_os = "linux", target_os = "macos")))]
 #[cfg(unix)]
 fn real_main() -> Result<(), ProfError> {
+    let version = clap::crate_version!();
+    let authors = clap::crate_authors!(", ");
+
     // create binary path argument
     let binary_arg = Arg::with_name("binary")
         .long("bin")
@@ -80,8 +83,8 @@ fn real_main() -> Result<(), ProfError> {
     // create callgrind subcommand
     let callgrind = SubCommand::with_name("callgrind")
         .about("gets callgrind features")
-        .version("1.0")
-        .author("Suchin Gururangan")
+        .version(version)
+        .author(authors)
         .arg(release.clone())
         .arg(binary_arg.clone())
         .arg(binargs_arg.clone())
@@ -91,8 +94,8 @@ fn real_main() -> Result<(), ProfError> {
     // create cachegrind subcommand
     let cachegrind = SubCommand::with_name("cachegrind")
         .about("gets cachegrind features")
-        .version("1.0")
-        .author("Suchin Gururangan")
+        .version(version)
+        .author(authors)
         .arg(release)
         .arg(binary_arg)
         .arg(binargs_arg.clone())
@@ -103,8 +106,8 @@ fn real_main() -> Result<(), ProfError> {
     // create profiler subcommand
     let profiler = SubCommand::with_name("profiler")
         .about("gets callgrind features")
-        .version("1.0")
-        .author("Suchin Gururangan")
+        .version(version)
+        .author(authors)
         .subcommand(callgrind)
         .subcommand(cachegrind);
 
@@ -112,8 +115,8 @@ fn real_main() -> Result<(), ProfError> {
     let matches = App::new("cargo-profiler")
         .bin_name("cargo")
         .settings(&[AppSettings::SubcommandRequired])
-        .version("1.0")
-        .author("Suchin Gururangan")
+        .version(version)
+        .author(authors)
         .about("Profile your binaries")
         .subcommand(profiler)
         .get_matches();


### PR DESCRIPTION
Each of the subcommands has a hard coded version of 1.0 and a hard-coded author name. This commit instead pulls this information directly from `Cargo.toml`, so that it can be upgraded from a centralized location.

I noticed this because it seems that the `--keep` flag is an enhancement not available on the version of `cargo-profiler` on crates.io, but I was erroneously seeing the version as 1.0.

One thing to note: the `Cargo.toml` has `pegasos1` as the original author, but the `.author` calls had "Suchin Gururangan". Should we also change `authors` like so?

`authors = ["Suchin Gururangan <pegasos1>", "Sven Hendrik Haase <svenstaro@gmail.com>"]`